### PR TITLE
Added enticement arrow for standards and dot navigations for select units page  

### DIFF
--- a/components/AboutPgComps/ShareWidget.js
+++ b/components/AboutPgComps/ShareWidget.js
@@ -107,7 +107,9 @@ const ShareWidget = ({
                         }}
                         className='d-flex justify-content-center align-items-center rounded-circle'
                     >
-                        <CopyIcon />
+                        <i
+                            className="bi bi-clipboard text-white"
+                        />
                     </button>
                 </CopyableTxt>
             </div>

--- a/components/Arrow.js
+++ b/components/Arrow.js
@@ -1,5 +1,5 @@
 const Arrow = ({ className = 'down-arrow' }) => (
-  <div className={className} />
+  <div className={className} style={{ color: 'black' }} />
 );
 
 export default Arrow;

--- a/components/ClickMeArrow.js
+++ b/components/ClickMeArrow.js
@@ -7,10 +7,6 @@ import { useEffect, useRef } from "react";
 import Arrow from "./Arrow";
 import { useInViewport } from "react-in-viewport";
 
-/**
- * Apart from the display field, the default object for the 'containerStyle' prop is as follows: 
- * { zIndex: 1000, bottom: '60px', right: '50px', display: showElementConditional ? 'none' : 'block' }
- * */
 const ClickMeArrow = ({
     handleElementVisibility,
     willShowArrow,
@@ -24,8 +20,6 @@ const ClickMeArrow = ({
     useEffect(() => {
         if (typeof handleElementVisibility === 'function') {
             handleElementVisibility(inViewport);
-        } else {
-            console.error('Did not pass a "handleElementVisibility" function.');
         }
     }, [inViewport]);
 
@@ -35,7 +29,6 @@ const ClickMeArrow = ({
             id='arrow-container'
             style={containerStyle}
             className={`position-absolute ${willShowArrow ? 'fade-in' : 'fade-out'}`}
-        // className={`position-absolute`}
         >
             <span style={clickToSeeMoreStyle} className='p-1 d-block fw-bold text-nowrap'>
                 {arrowTxt}

--- a/components/ClickMeArrow.js
+++ b/components/ClickMeArrow.js
@@ -8,9 +8,15 @@ import Arrow from "./Arrow";
 import { useInViewport } from "react-in-viewport";
 
 /**
- * The prop 'customDivStyling' must not include the display field.
+ * Apart from the display field, the default object for the 'containerStyle' prop is as follows: 
+ * { zIndex: 1000, bottom: '60px', right: '50px', display: showElementConditional ? 'none' : 'block' }
  * */
-const ClickMeArrow = ({ handleElementVisibility, customDivStyling, willTakeOffOfDom, willShowArrow }) => {
+const ClickMeArrow = ({
+    handleElementVisibility,
+    willShowArrow,
+    containerStyle = {},
+    clickToSeeMoreStyle = { transform: 'translateY(11px)', fontSize: 'clamp(17px, 2vw, 18px)' },
+}) => {
     const arrowContainerRef = useRef();
     const { inViewport } = useInViewport(arrowContainerRef);
 
@@ -26,10 +32,10 @@ const ClickMeArrow = ({ handleElementVisibility, customDivStyling, willTakeOffOf
         <div
             ref={arrowContainerRef}
             id='arrow-container'
-            style={{ ...customDivStyling, display: willTakeOffOfDom ? 'none' : 'block' }}
+            style={containerStyle}
             className={`position-absolute ${willShowArrow ? 'fade-in' : 'fade-out'}`}
         >
-            <span style={{ transform: 'translateY(11px)', fontSize: 'clamp(17px, 2vw, 18px)' }} className='p-1 d-block fw-bold text-nowrap'>
+            <span style={clickToSeeMoreStyle} className='p-1 d-block fw-bold text-nowrap'>
                 CLICK TO SEE MORE!
             </span>
             <Arrow className='down-arrow jump-infinite-animate' />

--- a/components/ClickMeArrow.js
+++ b/components/ClickMeArrow.js
@@ -33,7 +33,8 @@ const ClickMeArrow = ({
             ref={arrowContainerRef}
             id='arrow-container'
             style={containerStyle}
-            className={`position-absolute ${willShowArrow ? 'fade-in' : 'fade-out'}`}
+            // className={`position-absolute ${willShowArrow ? 'fade-in' : 'fade-out'}`}
+            className={`position-absolute`}
         >
             <span style={clickToSeeMoreStyle} className='p-1 d-block fw-bold text-nowrap'>
                 CLICK TO SEE MORE!

--- a/components/ClickMeArrow.js
+++ b/components/ClickMeArrow.js
@@ -21,8 +21,8 @@ const ClickMeArrow = ({
     const { inViewport } = useInViewport(arrowContainerRef);
 
     useEffect(() => {
-        if (handleElementVisibility) {
-            handleElementVisibility();
+        if (typeof handleElementVisibility === 'function') {
+            handleElementVisibility(inViewport);
         } else {
             console.error('Did not pass a "handleElementVisibility" function.');
         }

--- a/components/ClickMeArrow.js
+++ b/components/ClickMeArrow.js
@@ -15,7 +15,8 @@ const ClickMeArrow = ({
     handleElementVisibility,
     willShowArrow,
     containerStyle = {},
-    clickToSeeMoreStyle = { transform: 'translateY(11px)', fontSize: 'clamp(17px, 2vw, 18px)' },
+    clickToSeeMoreStyle = { transform: 'translateY(11px)', fontSize: 'clamp(17px, 2vw, 18px)', color: 'black' },
+    arrowTxt = "CLICK TO SEE MORE!",
 }) => {
     const arrowContainerRef = useRef();
     const { inViewport } = useInViewport(arrowContainerRef);
@@ -33,11 +34,11 @@ const ClickMeArrow = ({
             ref={arrowContainerRef}
             id='arrow-container'
             style={containerStyle}
-            // className={`position-absolute ${willShowArrow ? 'fade-in' : 'fade-out'}`}
-            className={`position-absolute`}
+            className={`position-absolute ${willShowArrow ? 'fade-in' : 'fade-out'}`}
+        // className={`position-absolute`}
         >
             <span style={clickToSeeMoreStyle} className='p-1 d-block fw-bold text-nowrap'>
-                CLICK TO SEE MORE!
+                {arrowTxt}
             </span>
             <Arrow className='down-arrow jump-infinite-animate' />
         </div>

--- a/components/ClickMeArrow.js
+++ b/components/ClickMeArrow.js
@@ -5,38 +5,29 @@
 /* eslint-disable react/jsx-indent */
 import { useEffect, useRef } from "react";
 import Arrow from "./Arrow";
-import throttle from "lodash.throttle";
 import { useInViewport } from "react-in-viewport";
 
-const ClickMeArrow = ({ _arrowContainer }) => {
-    const [arrowContainer, setArrowContainer] = _arrowContainer;
+/**
+ * The prop 'customDivStyling' must not include the display field.
+ * */
+const ClickMeArrow = ({ handleElementVisibility, customDivStyling, willTakeOffOfDom, willShowArrow }) => {
     const arrowContainerRef = useRef();
     const { inViewport } = useInViewport(arrowContainerRef);
 
-    let timer = null;
-
-    const handleElementVisibility = throttle(() => {
-        clearTimeout(timer);
-
-        if (inViewport) {
-            setArrowContainer(state => ({ ...state, isInView: true }));
-
-            timer = setTimeout(() => {
-                setArrowContainer(state => ({ ...state, isInView: false }));
-            }, 3500);
-        }
-    }, 100);
-
     useEffect(() => {
-        handleElementVisibility();
+        if (handleElementVisibility) {
+            handleElementVisibility();
+        } else {
+            console.error('Did not pass a "handleElementVisibility" function.');
+        }
     }, [inViewport]);
 
     return (
         <div
             ref={arrowContainerRef}
             id='arrow-container'
-            style={{ zIndex: 1000, bottom: '60px', right: '50px', display: arrowContainer.canTakeOffDom ? 'none' : 'block' }}
-            className={`position-absolute ${arrowContainer.isInView ? 'fade-in' : 'fade-out'}`}
+            style={{ ...customDivStyling, display: willTakeOffOfDom ? 'none' : 'block' }}
+            className={`position-absolute ${willShowArrow ? 'fade-in' : 'fade-out'}`}
         >
             <span style={{ transform: 'translateY(11px)', fontSize: 'clamp(17px, 2vw, 18px)' }} className='p-1 d-block fw-bold text-nowrap'>
                 CLICK TO SEE MORE!

--- a/components/LessonSection/LessonSecsNavDots.js
+++ b/components/LessonSection/LessonSecsNavDots.js
@@ -14,11 +14,12 @@
 /* eslint-disable no-console */
 import { useRouter } from "next/router";
 import LiNavDot from "./NavDots/LiNavDot";
-import { useState } from "react";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 
 const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListenerOn }) => {
     const [sectionDots, setSectionDots] = _sectionDots;
+    const [targetSec, setTargetSec] = useState(null);
+    const [willScrollElemIntoView, setWillScrollElemIntoView] = useState(false);
     const router = useRouter();
 
     const handleMouseEnter = () => {
@@ -49,8 +50,6 @@ const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListe
         });
     };
 
-    const [targetSec, setTargetSec] = useState(null);
-
     const scrollSectionIntoView = sectionId => {
         const targetSection = document.getElementById(sectionId);
         let url = router.asPath;
@@ -68,7 +67,6 @@ const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListe
         }
     }, [targetSec])
 
-    const [willScrollElemIntoView, setWillScrollElemIntoView] = useState(false);
     let timerForHandleDotClick;
 
     const handleDotClick = sectionId => {
@@ -167,6 +165,7 @@ const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListe
             style={{ transform: 'translateY(8%)' }}
             className="position-fixed lessonSecsNavDotsListContainer d-flex"
         >
+            {/* for devices larger than 992px */}
             <ul
                 onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}
                 className='ps-0 d-none d-lg-flex flex-column position-relative justify-content-center align-items-center h-100'
@@ -181,6 +180,7 @@ const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListe
                     />
                 ))}
             </ul>
+            {/* for devices smaller than 991px */}
             <ul className='ps-0 d-flex d-lg-none flex-column position-relative justify-content-center align-items-center h-100' style={{ transform: 'translate3d(0px, 0px, 0px)', 'transitionDuration': '3500ms', transition: 'all .15s ease-in' }}>
                 {sectionDots.dots.map((section, index) => (
                     <LiNavDot

--- a/components/LessonSection/LessonSecsNavDots.js
+++ b/components/LessonSection/LessonSecsNavDots.js
@@ -22,9 +22,20 @@ const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListe
     const [sectionDots, setSectionDots] = _sectionDots;
     const [targetSec, setTargetSec] = useState(null);
     const [willScrollElemIntoView, setWillScrollElemIntoView] = useState(false);
+    const [arrowContainer, setArrowContainer] = useState({ isInView: true, canTakeOffDom: false })
     const router = useRouter();
 
+    useEffect(() => {
+        const overviewSection = sectionDots.dots.find(({ sectionTitleForDot }) => sectionTitleForDot.toLowerCase() === 'overview')
+
+        if (!overviewSection.isInView && arrowContainer.isInView) {
+            setArrowContainer({ isInView: false, canTakeOffDom: false })
+        }
+    }, [sectionDots])
+
     const handleMouseEnter = () => {
+        setArrowContainer({ isInView: false, canTakeOffDom: true });
+
         setSectionDots(sectionDots => {
             return {
                 ...sectionDots,
@@ -161,11 +172,11 @@ const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListe
     }, [willScrollElemIntoView, isScrollListenerOn])
 
     const liNavDotFns = { goToSection, handleDotClick, setSectionDots }
-
-    const [arrowContainer, setArrowContainer] = useState({ isInView: false, canTakeOffDom: false });
-
     let timer;
 
+    // delete the arrow when the following occurs:
+    // -when the user starts scrolling 
+    // -when the user hovers over the dots
     const handleElementVisibility = inViewPort => (throttle(() => {
         clearTimeout(timer);
 
@@ -193,10 +204,11 @@ const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListe
                         key={index}
                         EnticementArrow={(index === 0) ?
                             <ClickMeArrow
+                                arrowTxt="Skip to Section"
                                 handleElementVisibility={handleElementVisibility}
                                 willShowArrow={arrowContainer.isInView}
-                                containerStyle={{ zIndex: 1000, right: '50px', display: arrowContainer.canTakeOffDom ? 'none' : 'block' }}
-                                clickToSeeMoreStyle={{ fontSize: 'clamp(17px, 2vw, 18px)' }}
+                                containerStyle={{ zIndex: 1000, right: "40px", bottom: "65px", display: arrowContainer.canTakeOffDom ? 'none' : 'block' }}
+                                clickToSeeMoreStyle={{ fontSize: 'clamp(17px, 2vw, 18px)', transform: 'translateY(10px)' }}
                             />
                             :
                             null

--- a/components/LessonSection/LessonSecsNavDots.js
+++ b/components/LessonSection/LessonSecsNavDots.js
@@ -15,6 +15,8 @@
 import { useRouter } from "next/router";
 import LiNavDot from "./NavDots/LiNavDot";
 import { useState, useEffect } from "react";
+import ClickMeArrow from "../ClickMeArrow";
+import throttle from "lodash.throttle";
 
 const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListenerOn }) => {
     const [sectionDots, setSectionDots] = _sectionDots;
@@ -160,6 +162,22 @@ const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListe
 
     const liNavDotFns = { goToSection, handleDotClick, setSectionDots }
 
+    const [arrowContainer, setArrowContainer] = useState({ isInView: false, canTakeOffDom: false });
+
+    let timer;
+
+    const handleElementVisibility = inViewPort => (throttle(() => {
+        clearTimeout(timer);
+
+        if (inViewPort) {
+            setArrowContainer(state => ({ ...state, isInView: true }));
+
+            timer = setTimeout(() => {
+                setArrowContainer(state => ({ ...state, isInView: false }));
+            }, 3500);
+        }
+    }, 200))();
+
     return (
         <div
             style={{ transform: 'translateY(8%)' }}
@@ -173,6 +191,16 @@ const LessonsSecsNavDots = ({ _sectionDots, setIsScrollListenerOn, isScrollListe
                 {sectionDots.dots.map((section, index) => (
                     <LiNavDot
                         key={index}
+                        EnticementArrow={(index === 0) ?
+                            <ClickMeArrow
+                                handleElementVisibility={handleElementVisibility}
+                                willShowArrow={arrowContainer.isInView}
+                                containerStyle={{ zIndex: 1000, right: '50px', display: arrowContainer.canTakeOffDom ? 'none' : 'block' }}
+                                clickToSeeMoreStyle={{ fontSize: 'clamp(17px, 2vw, 18px)' }}
+                            />
+                            :
+                            null
+                        }
                         fns={liNavDotFns}
                         section={section}
                         index={index}

--- a/components/LessonSection/NavDots/LiNavDot.js
+++ b/components/LessonSection/NavDots/LiNavDot.js
@@ -40,14 +40,16 @@ const LiNavDot = ({ section, fns, index, isOnDesktop, EnticementArrow = <></> })
                     onClick={_ => goToSection(sectionId)}
                     className='d-flex flex-inline justify-content-center align-items-center position-relative sectionNavDotLi'
                 >
-                    {EnticementArrow}
-                    <i
-                        onMouseOver={handleMouseOverIcon}
-                        onMouseLeave={handleMouseLeaveIcon}
-                        style={iconStyles}
-                        className='sectionNavDot'
-                        id={sectionDotId}
-                    />
+                    <div>
+                        <i
+                            onMouseOver={handleMouseOverIcon}
+                            onMouseLeave={handleMouseLeaveIcon}
+                            style={iconStyles}
+                            className='sectionNavDot'
+                            id={sectionDotId}
+                        />
+                        {EnticementArrow}
+                    </div>
                     <div style={{ zIndex: 1100, opacity: willShowTitle ? 1 : 0, width: 'auto', right: '25px', transition: "all .15s ease-in", pointerEvents: 'none', backgroundColor: backgroundColor, border: '#363636 1px solid', transitionProperty: 'background-color, opacity, border' }} className='p-1 rounded position-absolute d-flex'>
                         <span className='text-nowrap'>{title}</span>
                         <span style={{ width: 55 }} className='d-flex d-md-none justify-content-center align-items-center ps-1 sectionTitleSpan'>

--- a/components/LessonSection/NavDots/LiNavDot.js
+++ b/components/LessonSection/NavDots/LiNavDot.js
@@ -13,13 +13,12 @@
 
 import { useMemo, useState } from "react";
 import { getIconStyles } from "../../../helperFns/getIconStyles";
-import { useEffect } from "react";
 
-const LiNavDot = ({ section, fns, index, isOnDesktop }) => {
+const LiNavDot = ({ section, fns, index, isOnDesktop, EnticementArrow = <></> }) => {
     const { isInView, sectionId, sectionTitleForDot: title, willShowTitle, sectionDotId } = section;
     const [willChangeIconColor, setWillChangeIconColor] = useState(false)
     const { goToSection, handleDotClick } = fns;
-    const backgroundColor = isInView ? (sectionId === '3._teaching_materials') ? '#FEEAF8' : '#d5e6f3' : 'white'
+    const backgroundColor = isInView ? ((sectionId === '3._teaching_materials') ? '#FEEAF8' : '#d5e6f3') : 'white'
 
     const handleMouseOverIcon = () => {
         setWillChangeIconColor(true);
@@ -41,6 +40,7 @@ const LiNavDot = ({ section, fns, index, isOnDesktop }) => {
                     onClick={_ => goToSection(sectionId)}
                     className='d-flex flex-inline justify-content-center align-items-center position-relative sectionNavDotLi'
                 >
+                    {EnticementArrow}
                     <i
                         onMouseOver={handleMouseOverIcon}
                         onMouseLeave={handleMouseLeaveIcon}

--- a/components/LessonSection/Standards/StandardsGroup.js
+++ b/components/LessonSection/Standards/StandardsGroup.js
@@ -5,6 +5,7 @@ import Accordion from '../../Accordion';
 import RichText from '../../RichText';
 import { useState } from 'react';
 import CopyableTxt from '../../CopyableTxt';
+import ClickMeArrow from '../../ClickMeArrow';
 
 const CopyIcon = ({ color = 'white' }) => (
   <svg
@@ -47,17 +48,22 @@ const StandardsGroup = ({
   grades,
   alignmentNotes,
   statements,
+  willShowArrow,
+  _arrowContainer,
+  handleElementVisibility,
 }) => {
+  const index = id.split('-').at(-1);
   const _grades = Array.isArray(grades) ? grades.join(',') : grades;
   const [contentId, setContentId] = useState('');
   const [isAccordionContentDisplayed, setIsAccordionContentDisplayed] = useState(false);
-
+  const [arrowContainer, setArrowContainer] = _arrowContainer;
   const handleClickToCopyTxt = (event, txt) => {
     event.stopPropagation();
     navigator.clipboard.writeText(txt);
   };
 
   const handleOnClick = () => {
+    setArrowContainer({ isInView: false, canTakeOffDom: true });
     setIsAccordionContentDisplayed(prevState => !prevState);
   };
 
@@ -105,8 +111,19 @@ const StandardsGroup = ({
                 <h6 className='text-muted w-100 d-flex justify-content-between'>
                   {formatGrades(_grades)}
                   <div
-                    className="d-flex justify-content-center flex-column h-100"
+                    className="d-flex justify-content-center flex-column h-100 position-relative"
                   >
+                    {((index == 0) && willShowArrow) ? (
+                      <ClickMeArrow
+                        handleElementVisibility={handleElementVisibility}
+                        willShowArrow={arrowContainer.isInView}
+                        containerStyle={{ zIndex: 1000, bottom: '70px', right: '35px', display: arrowContainer.canTakeOffDom ? 'none' : 'block' }}
+                        arrowTxt='Click for Details'
+                      />
+                    )
+                      :
+                      null
+                    }
                     <i
                       color="#7A8489"
                       style={{ display: isAccordionContentDisplayed ? 'none' : 'block' }}

--- a/components/LessonSection/Standards/Subject.js
+++ b/components/LessonSection/Standards/Subject.js
@@ -2,18 +2,30 @@
 /* eslint-disable quotes */
 /* eslint-disable no-console */
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
 import Accordion from '../../Accordion';
 import StandardsGroup from './StandardsGroup';
+import ClickMeArrow from '../../ClickMeArrow';
+import { useArrowContainer } from '../../../customHooks/useArrowContainer';
 
 const Subject = ({
   accordionId,
   sets,
   subject,
   initiallyExpanded,
+  areThereTargetStandards,
+  handleSubjectAccordionBtnClick = () => {
+    console.warn("Default function was executed for 'handleSubjectAccordionBtnClick.'");
+  },
+  handleSubjectElementVisibility = () => {
+
+  },
+  arrowContainer,
 }) => {
+  const { _arrowContainer: _arrowContainerForStandsElementVisibility, handleElementVisibility: handleStandardsElementVisibility } = useArrowContainer();
+  const index = accordionId.split('-').at(-1);
   const subjectSlug = subject.toLowerCase().replace(/\s/g, '');
   const subjectDimensions = sets[0].dimensions;
+
   let subjectSlugIds;
 
   if (subjectDimensions.length > 1) {
@@ -26,10 +38,20 @@ const Subject = ({
       initiallyExpanded={initiallyExpanded}
       buttonClassName={`w-100 border-0 text-start bg-${subjectSlug} text-white`}
       button={(
-        <h5 className='mb-0 p-2 d-flex justify-content-between align-items-center'>
+        <h5 onClick={handleSubjectAccordionBtnClick} className='mb-0 p-2 d-flex justify-content-between align-items-center'>
           {subject} - {sets[0].name}
-          <i className="fs-5 bi-chevron-down "></i>
-          <i className="fs-5 bi-chevron-up"></i>
+          <div className='position-relative'>
+            {((index == 0) && !areThereTargetStandards) && (
+              <ClickMeArrow
+                handleElementVisibility={handleSubjectElementVisibility}
+                willShowArrow={arrowContainer.isInView}
+                containerStyle={{ zIndex: 1000, bottom: '70px', right: '35px', display: arrowContainer.canTakeOffDom ? 'none' : 'block' }}
+                arrowTxt='Click to view Details'
+              />
+            )}
+            <i className="fs-5 bi-chevron-down"></i>
+            <i className="fs-5 bi-chevron-up"></i>
+          </div>
         </h5>
       )}
     >
@@ -42,11 +64,14 @@ const Subject = ({
           }
 
           return (
-            <div className={`bg-${subjectSlug}-light p-2  mx-1 `} key={subjectDimIndex}>
+            <div className={`bg-${subjectSlug}-light p-2  mx-1`} key={subjectDimIndex}>
               <p className='mb-1 p-1'><strong>Dimension:</strong> {name}</p>
               {standardsGroup.map((group, groupIndex) => (
                 <StandardsGroup
                   id={`${subjectSlugIdName}-${groupIndex}`}
+                  _arrowContainer={_arrowContainerForStandsElementVisibility}
+                  handleElementVisibility={handleStandardsElementVisibility}
+                  willShowArrow={subjectDimIndex == 0 && index == 0}
                   key={groupIndex}
                   {...group}
                 />

--- a/components/LessonSection/Standards/index.js
+++ b/components/LessonSection/Standards/index.js
@@ -3,11 +3,19 @@ import PropTypes from 'prop-types';
 import { useRef } from 'react';
 import Accordion from '../../Accordion';
 import Subject from './Subject';
+import { useArrowContainer } from '../../../customHooks/useArrowContainer';
 
 const Standards = ({
   Data,
 }) => {
   const ref = useRef();
+  const areThereTargetStandards = Data?.some(({ target }) => target);
+  const { _arrowContainer, handleElementVisibility } = useArrowContainer();
+  const [arrowContainer, setArrowContainer] = _arrowContainer;
+
+  const handleSubjectAccordionBtnClick = () => {
+    setArrowContainer({ isInView: false, canTakeOffDom: true });
+  };
 
   return (
     <div ref={ref} className='container mb-4 px-0'>
@@ -23,6 +31,7 @@ const Standards = ({
           </div>
         )}
       >
+        {/* if there are no target standards, then show the arrow for the first section for the connected standars */}
         <div>
           <h4 className='fs-5 fw-bold mt-4 mb-1'><i className="bi bi-bullseye me-2" />Target Standard(s)</h4>
           <div className="mb-3">
@@ -32,6 +41,10 @@ const Standards = ({
             <Subject
               initiallyExpanded
               key={`target-${i}`}
+              areThereTargetStandards={areThereTargetStandards}
+              handleSubjectAccordionBtnClick={arrowContainer.canTakeOffDom ? null : handleSubjectAccordionBtnClick}
+              handleSubjectElementVisibility={handleElementVisibility}
+              arrowContainer={arrowContainer}
               accordionId={`target-${i}`}
               {...subject}
             />
@@ -45,6 +58,10 @@ const Standards = ({
             <Subject
               key={`connected-${i}`}
               accordionId={`connected-${i}`}
+              handleSubjectAccordionBtnClick={arrowContainer.canTakeOffDom ? null : handleSubjectAccordionBtnClick}
+              areThereTargetStandards={areThereTargetStandards}
+              handleSubjectElementVisibility={handleElementVisibility}
+              arrowContainer={arrowContainer}
               {...subject}
             />
           ))}

--- a/components/LessonSection/TeachIt/index.js
+++ b/components/LessonSection/TeachIt/index.js
@@ -342,7 +342,7 @@ const TeachIt = ({
                   <ClickMeArrow
                     handleElementVisibility={handleElementVisibility}
                     willShowArrow={arrowContainer.isInView}
-                    containerStyle={{ zIndex: 1000, bottom: '60px', right: '50px', display: arrowContainer.isInView ? 'none' : 'block' }}
+                    containerStyle={{ zIndex: 1000, bottom: '60px', right: '50px', display: arrowContainer.canTakeOffDom ? 'none' : 'block' }}
                   />
                   :
                   null

--- a/components/LessonSection/TeachIt/index.js
+++ b/components/LessonSection/TeachIt/index.js
@@ -18,7 +18,7 @@ import Link from "next/link";
 import Button from "../../General/Button";
 import { getIsValObj, getObjVals } from "../../../globalFns";
 import { UNVIEWABLE_LESSON_STR } from "../../../globalVars";
-import Arrow from "../../ClickMeArrow";
+import ClickMeArrow from "../../ClickMeArrow";
 import throttle from "lodash.throttle";
 
 const LessonTile = ({
@@ -338,7 +338,15 @@ const TeachIt = ({
                 {...lessonTilesObj}
                 removeClickToSeeMoreTxt={removeClickToSeeMoreTxt}
                 key={`${index}_part`}
-                ClickToSeeMoreComp={index === 0 ? <Arrow handleElementVisibility={handleElementVisibility} /> : null}
+                ClickToSeeMoreComp={index === 0 ?
+                  <ClickMeArrow
+                    handleElementVisibility={handleElementVisibility}
+                    willShowArrow={arrowContainer.isInView}
+                    containerStyle={{ zIndex: 1000, bottom: '60px', right: '50px', display: arrowContainer.isInView ? 'none' : 'block' }}
+                  />
+                  :
+                  null
+                }
                 FeedbackComp={(part.status === "Beta") ? (
                   <SendFeedback
                     parentDivStyles={{ backgroundColor: '#EBD0FF', zIndex: 100, border: '1px solid #B7B6C2' }}

--- a/components/LessonSection/TeachIt/index.js
+++ b/components/LessonSection/TeachIt/index.js
@@ -73,7 +73,7 @@ const TeachIt = ({
 }) => {
   const { _isDownloadModalInfoOn } = useContext(ModalContext);
   const [, setIsDownloadModalInfoOn] = _isDownloadModalInfoOn;
-  const [arrowContainer, setArrowContainer] = useState({ isInView: false, canTakeOffDom: false });
+  const [arrowContainer, setArrowContainer] = useState({ isInView: true, canTakeOffDom: false });
   const [numsOfLessonPartsThatAreExpanded, setNumsOfLessonPartsThatAreExpanded] = useState([]);
   const [, setSectionDots] = _sectionDots;
   const environments = ['classroom', 'remote'].filter(setting => Object.prototype.hasOwnProperty.call(Data, setting));

--- a/components/LessonSection/TeachIt/index.js
+++ b/components/LessonSection/TeachIt/index.js
@@ -18,7 +18,8 @@ import Link from "next/link";
 import Button from "../../General/Button";
 import { getIsValObj, getObjVals } from "../../../globalFns";
 import { UNVIEWABLE_LESSON_STR } from "../../../globalVars";
-import ClickMeArrow from "../../ClickMeArrow";
+import Arrow from "../../ClickMeArrow";
+import throttle from "lodash.throttle";
 
 const LessonTile = ({
   lessonTileUrl,
@@ -124,6 +125,20 @@ const TeachIt = ({
     setSelectedGradeResources(selectedGrade.links);
     setSelectedGrade(selectedGrade);
   };
+
+  let timer;
+
+  const handleElementVisibility = throttle(() => {
+    clearTimeout(timer);
+
+    if (arrowContainer.inViewport) {
+      setArrowContainer(state => ({ ...state, isInView: true }));
+
+      timer = setTimeout(() => {
+        setArrowContainer(state => ({ ...state, isInView: false }));
+      }, 3500);
+    }
+  }, 100);
 
   useEffect(() => {
     const lessonPartPath = window.location.href.split("#").at(-1);
@@ -323,7 +338,7 @@ const TeachIt = ({
                 {...lessonTilesObj}
                 removeClickToSeeMoreTxt={removeClickToSeeMoreTxt}
                 key={`${index}_part`}
-                ClickToSeeMoreComp={index === 0 ? <ClickMeArrow _arrowContainer={[arrowContainer, setArrowContainer]} /> : null}
+                ClickToSeeMoreComp={index === 0 ? <Arrow handleElementVisibility={handleElementVisibility} /> : null}
                 FeedbackComp={(part.status === "Beta") ? (
                   <SendFeedback
                     parentDivStyles={{ backgroundColor: '#EBD0FF', zIndex: 100, border: '1px solid #B7B6C2' }}

--- a/components/LessonSection/TeachIt/index.js
+++ b/components/LessonSection/TeachIt/index.js
@@ -128,17 +128,17 @@ const TeachIt = ({
 
   let timer;
 
-  const handleElementVisibility = throttle(() => {
+  const handleElementVisibility = inViewPort => (throttle(() => {
     clearTimeout(timer);
 
-    if (arrowContainer.inViewport) {
+    if (inViewPort) {
       setArrowContainer(state => ({ ...state, isInView: true }));
 
       timer = setTimeout(() => {
         setArrowContainer(state => ({ ...state, isInView: false }));
       }, 3500);
     }
-  }, 100);
+  }, 200))();
 
   useEffect(() => {
     const lessonPartPath = window.location.href.split("#").at(-1);

--- a/components/LessonsPg/sections/GpWebApps.js
+++ b/components/LessonsPg/sections/GpWebApps.js
@@ -32,10 +32,10 @@ const GpWebApps = ({
                                 />
                             </div>
                             <section className="d-flex justify-content-center align-items-left flex-column">
-                                <h4 className='fw-light text-black mb-0 pb-1 text-center mt-2'>
+                                <h4 className='fw-light text-black mb-0 pb-1 text-left mt-2'>
                                     {webApp.title}
                                 </h4>
-                                <span style={{ lineHeight: '20px', transform: 'translateY(5px)' }} className="text-black text-left text-center mt-1 mt-sm-0">
+                                <span style={{ lineHeight: '20px', transform: 'translateY(5px)' }} className="text-black text-left mt-1 mt-sm-0">
                                     {webApp.description}
                                 </span>
                             </section>

--- a/customHooks/useArrowContainer.js
+++ b/customHooks/useArrowContainer.js
@@ -1,0 +1,23 @@
+/* eslint-disable quotes */
+/* eslint-disable indent */
+import throttle from "lodash.throttle";
+import { useState } from "react";
+
+export const useArrowContainer = (throttleMs = 200, fadeOutArrowContainerTimeoutMs = 3500) => {
+    const [arrowContainer, setArrowContainer] = useState({ isInView: true, canTakeOffDom: false });
+    let timer;
+
+    const handleElementVisibility = inViewPort => (throttle(() => {
+        clearTimeout(timer);
+
+        if (inViewPort) {
+            setArrowContainer(state => ({ ...state, isInView: true }));
+
+            timer = setTimeout(() => {
+                setArrowContainer(state => ({ ...state, isInView: false }));
+            }, fadeOutArrowContainerTimeoutMs);
+        }
+    }, throttleMs))();
+
+    return { _arrowContainer: [arrowContainer, setArrowContainer], handleElementVisibility };
+};

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -43,7 +43,6 @@ const getLessonSections = sectionComps => sectionComps.map((section, index) => (
 }));
 
 const LessonDetails = ({ lesson }) => {
-  console.log("lesson: ", lesson);
   const router = useRouter();
   const lessonSectionObjEntries = lesson?.Section ? Object.entries(lesson.Section) : [];
   let lessonStandardsIndexesToFilterOut = [];
@@ -108,6 +107,14 @@ const LessonDetails = ({ lesson }) => {
 
     sectionComps.splice(backgroundSectionIndex + 1, 0, lessonStandardsObj)
   }
+
+  sectionComps = sectionComps.filter(section => {
+    if (("Data" in section) && !section['Data']) {
+      return false;
+    }
+
+    return true;
+  })
 
   const _dots = sectionComps ? getSectionDotsDefaultVal(sectionComps) : [];
   const [sectionDots, setSectionDots] = useState({
@@ -465,8 +472,12 @@ export const getStaticProps = async ({ params: { id, loc } }) => {
       }
     }
 
-    if (lessonToDisplayOntoUi?.Section?.preview?.Multimedia) {
-      // check if the videos has any shorts in them. 
+    if (lessonToDisplayOntoUi?.Section?.preview?.Multimedia?.length) {
+      for (const multiMedia of lessonToDisplayOntoUi.Section.preview.Multimedia) {
+        if (multiMedia.mainLink.includes('www.youtube.com/shorts')) {
+          multiMedia.mainLink = multiMedia.mainLink.replace('shorts', 'embed');
+        }
+      }
     }
 
     return {

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -43,6 +43,7 @@ const getLessonSections = sectionComps => sectionComps.map((section, index) => (
 }));
 
 const LessonDetails = ({ lesson }) => {
+  console.log("lesson: ", lesson);
   const router = useRouter();
   const lessonSectionObjEntries = lesson?.Section ? Object.entries(lesson.Section) : [];
   let lessonStandardsIndexesToFilterOut = [];

--- a/pages/lessons/index.js
+++ b/pages/lessons/index.js
@@ -170,10 +170,10 @@ const LessonsPage = ({
                       <JobVizIcon />
                     </section>
                     <section className="d-flex justify-content-center align-items-left flex-column ps-3">
-                      <h4 className='fw-light text-black mb-0 pb-1 text-center mt-1 mt-sm-2 my-2'>
+                      <h4 className='fw-light text-black mb-0 pb-1 text-left mt-1 mt-sm-2 my-2'>
                         Jobviz Career Explorer
                       </h4>
-                      <span className="text-black text-center mt-1 mt-sm-0">A starting point for students to explore 1,000 job possibilities</span>
+                      <span className="text-black text-left mt-1 mt-sm-0">A starting point for students to explore 1,000 job possibilities</span>
                     </section>
                   </section>
                 </div>


### PR DESCRIPTION
A couple of things that I spotted that may have something to do with the json documents in the DB: 

- There are no 'grades' for lesson/13. I implemented some logic to handle this case (first screenshot). 
- For lesson/10, the value for the data field is null for the 'Acknowledgements' section (see the second screenshot). 
- And (unrelated to the JSON documents) there is a problem with the epaulette image for lesson/13 (third screenshot).

Besides that, I think the branch is ready to merge with main.

![Screenshot 2024-06-26 083120](https://github.com/galacticpolymath/gp-frontend/assets/67920345/80c99c07-39fc-49ea-8a26-10119f4b15b5)
![Screenshot 2024-06-26 083805](https://github.com/galacticpolymath/gp-frontend/assets/67920345/2b3ca47a-87ca-4f7a-aa20-9e5843de915e)
![Screenshot 2024-06-26 084617](https://github.com/galacticpolymath/gp-frontend/assets/67920345/ca22be29-5ca9-4ebc-a68c-f9b70c56c274)

