### PR TITLE
Updated the UI for the selected unit page (/lessons/{locale}/{numID}), discovered null values in JSON document

### DIFF
--- a/components/LessonSection/GistCard.js
+++ b/components/LessonSection/GistCard.js
@@ -12,6 +12,7 @@ const GistCard = ({
   SteamEpaulette_vert,
   isOnPreview,
 }) => {
+
   return (
     <div className="bg-light-gray px-4 py-2 mt-4 rounded-3 text-center">
       {LearningSummary && (

--- a/components/LessonSection/Overview.js
+++ b/components/LessonSection/Overview.js
@@ -17,6 +17,7 @@ const Overview = ({
   SteamEpaulette_vert,
   Text,
   Tags,
+  GradesOrYears,
   _sectionDots,
   SectionTitle,
   ...titleProps
@@ -67,7 +68,7 @@ const Overview = ({
             <div className='d-none d-sm-grid g-col g-col-6 g-col-sm-4 bg-white p-3 rounded-3 '>
               <span>
                 <i className="fs-3 mb-2 me-2 bi-person-circle"></i>
-                <h5 className='d-inline-block'>Grades: </h5>
+                <h5 className='d-inline-block'>{GradesOrYears}: </h5>
               </span>
               <div>{ForGrades}</div>
             </div>
@@ -88,7 +89,7 @@ const Overview = ({
             <div className='d-sm-none g-col-12 align-items-center justify-content-center'>
               <div className='d-grid bg-white rounded-3 col-12 p-3'>
                 <i className="fs-3 mb-2 d-block bi-person-circle"></i>
-                <h5>Grades: </h5>
+                <h5>{GradesOrYears}: </h5>
                 <span>{ForGrades}</span>
               </div>
             </div>

--- a/components/LessonSection/Standards/StandardsCollapsible.js
+++ b/components/LessonSection/Standards/StandardsCollapsible.js
@@ -11,6 +11,7 @@ const StandardsCollapsible = ({
   Badge,
   Data,
   Description,
+  GradesOrYears,
   Title,
   Footnote = '',
 }) => {
@@ -36,7 +37,7 @@ const StandardsCollapsible = ({
           />
         )}
         <div className={Badge ? '' : 'pt-3'}>
-          <Standards Data={Data} />
+          <Standards Data={Data} GradesOrYears={GradesOrYears} />
         </div>
       </div>
     </CollapsibleLessonSection>

--- a/components/LessonSection/Standards/StandardsGroup.js
+++ b/components/LessonSection/Standards/StandardsGroup.js
@@ -24,7 +24,7 @@ const CopyIcon = ({ color = 'white' }) => (
   </svg>
 );
 
-const formatGrades = grades => {
+const formatGrades = (grades, gradesOrYears = 'Grades') => {
   if (!grades) {
     return '';
   }
@@ -32,10 +32,10 @@ const formatGrades = grades => {
   const parsedGrades = (Array.isArray(grades) ? grades : grades.split(',')).map((x) => x.replace(/^0/, ''));
 
   if (parsedGrades.length === 1) {
-    return `Grade: ${parsedGrades[0]}`;
+    return `${gradesOrYears.slice(0, -1)}: ${parsedGrades[0]}`;
   }
 
-  return `Grades: ${parsedGrades[0]}-${parsedGrades[parsedGrades.length - 1]}`;
+  return `${gradesOrYears}: ${parsedGrades[0]}-${parsedGrades[parsedGrades.length - 1]}`;
 };
 
 export const formatAlignmentNotes = (text) => {
@@ -46,6 +46,7 @@ const StandardsGroup = ({
   id,
   codes,
   grades,
+  GradesOrYears,
   alignmentNotes,
   statements,
   willShowArrow,
@@ -108,8 +109,8 @@ const StandardsGroup = ({
                 data-bs-toggle='collapse'
                 data-bs-target={`#content_${contentId}`}
               >
-                <h6 className={`text-muted w-100 d-flex ${(Array.isArray(grades) && (grades.length > 0)) ? 'justify-content-between' : 'justify-content-end'}`}>
-                  {formatGrades(_grades)}
+                <h6 className={`text-muted w-100 d-flex ${(Array.isArray(grades) && (grades.length > 0) || ((typeof grades === 'string') && (grades.length > 0))) ? 'justify-content-between' : 'justify-content-end'}`}>
+                  {formatGrades(_grades, GradesOrYears)}
                   <div
                     className="d-flex justify-content-center flex-column h-100 position-relative"
                   >

--- a/components/LessonSection/Standards/Subject.js
+++ b/components/LessonSection/Standards/Subject.js
@@ -11,6 +11,7 @@ const Subject = ({
   accordionId,
   sets,
   subject,
+  GradesOrYears,
   initiallyExpanded,
   areThereTargetStandards,
   handleSubjectAccordionBtnClick = () => {
@@ -31,8 +32,6 @@ const Subject = ({
   if (subjectDimensions.length > 1) {
     subjectSlugIds = new Array(subjectDimensions.length).fill(subjectSlug).map((subjectSlugId, index) => `${subjectSlugId}-${index}`);
   }
-
-  console.log("yo there: ", subjectSlug);
 
   return (
     <Accordion
@@ -71,6 +70,7 @@ const Subject = ({
               {standardsGroup.map((group, groupIndex) => (
                 <StandardsGroup
                   id={`${subjectSlugIdName}-${groupIndex}`}
+                  GradesOrYears={GradesOrYears}
                   _arrowContainer={_arrowContainerForStandsElementVisibility}
                   handleElementVisibility={handleStandardsElementVisibility}
                   willShowArrow={subjectDimIndex == 0 && index == 0}

--- a/components/LessonSection/Standards/Subject.js
+++ b/components/LessonSection/Standards/Subject.js
@@ -32,6 +32,8 @@ const Subject = ({
     subjectSlugIds = new Array(subjectDimensions.length).fill(subjectSlug).map((subjectSlugId, index) => `${subjectSlugId}-${index}`);
   }
 
+  console.log("yo there: ", subjectSlug);
+
   return (
     <Accordion
       id={accordionId}

--- a/components/LessonSection/Standards/index.js
+++ b/components/LessonSection/Standards/index.js
@@ -7,6 +7,7 @@ import { useArrowContainer } from '../../../customHooks/useArrowContainer';
 
 const Standards = ({
   Data,
+  GradesOrYears,
 }) => {
   const ref = useRef();
   const areThereTargetStandards = Data?.some(({ target }) => target);
@@ -40,6 +41,7 @@ const Standards = ({
           {Data.filter(({ target }) => target).map((subject, i) => (
             <Subject
               initiallyExpanded
+              GradesOrYears={GradesOrYears}
               key={`target-${i}`}
               areThereTargetStandards={areThereTargetStandards}
               handleSubjectAccordionBtnClick={arrowContainer.canTakeOffDom ? null : handleSubjectAccordionBtnClick}

--- a/components/LessonSection/TeachIt/LessonPart.js
+++ b/components/LessonSection/TeachIt/LessonPart.js
@@ -25,6 +25,7 @@ const LessonPart = ({
   chunks = [],
   resources,
   ForGrades,
+  GradesOrYears,
   _numsOfLessonPartsThatAreExpanded,
   removeClickToSeeMoreTxt,
   lessonTileForDesktop = null,
@@ -376,7 +377,7 @@ const LessonPart = ({
           <div className='mt-4 pb-1'>
             <div className='d-flex align-items-start'>
               <i className="bi bi-ui-checks-grid me-2 fw-bolder"></i>
-              <h5 className="fw-bold">Materials for Grades {ForGrades}</h5>
+              <h5 className="fw-bold">Materials for {GradesOrYears} {ForGrades}</h5>
             </div>
             <ol className='mt-2 materials-list'>
               {!!_itemList?.length && _itemList.map((item, itemIndex) => {

--- a/components/LessonSection/TeachIt/index.js
+++ b/components/LessonSection/TeachIt/index.js
@@ -72,6 +72,7 @@ const TeachIt = ({
   Data,
   _sectionDots,
   ForGrades,
+  GradesOrYears,
 }) => {
   const { _isDownloadModalInfoOn } = useContext(ModalContext);
   const [, setIsDownloadModalInfoOn] = _isDownloadModalInfoOn;
@@ -192,7 +193,7 @@ const TeachIt = ({
         </div>
         <div className="container row mx-auto py-4">
           <div className="col w-1/2">
-            <h3 className='fs-5'>Available Grade Bands</h3>
+            <h3 className='fs-5'>Available {GradesOrYears} Bands</h3>
             {!!gradeVariations.length && gradeVariations.map((variation, i) => (
               <label
                 key={i}
@@ -338,6 +339,7 @@ const TeachIt = ({
             return (
               <LessonPart
                 {...lessonTilesObj}
+                GradesOrYears={GradesOrYears}
                 removeClickToSeeMoreTxt={removeClickToSeeMoreTxt}
                 key={`${index}_part`}
                 ClickToSeeMoreComp={index === 0 ?

--- a/components/LessonSection/TeachIt/index.js
+++ b/components/LessonSection/TeachIt/index.js
@@ -31,14 +31,16 @@ const LessonTile = ({
   return (
     <div style={imgContainerStyle} className={imgContainerClassNameStr}>
       {Pill}
-      <Image
-        src={lessonTileUrl}
-        alt="lesson_tile"
-        fill
-        style={imgStyle}
-        sizes="130px"
-        className="img-optimize rounded w-100 h-100"
-      />
+      {lessonTileUrl && (
+        <Image
+          src={lessonTileUrl}
+          alt="lesson_tile"
+          fill
+          style={imgStyle}
+          sizes="130px"
+          className="img-optimize rounded w-100 h-100"
+        />
+      )}
     </div>
   );
 };

--- a/components/LessonSection/index.js
+++ b/components/LessonSection/index.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import Overview from './Overview';
 import Heading from './Heading.js';
 import TeachIt from './TeachIt';
-import LearningChart from './LearningChart';
 import Acknowledgments from './Acknowledgments';
 import Versions from './Versions';
 import CollapsibleRichTextSection from './CollapsibleRichTextSection';
@@ -50,13 +49,12 @@ export const NUMBERED_SECTIONS = [
 export const sectionTypeMap = {
   [SECTIONS.OVERVIEW]: Overview,
   [SECTIONS.HEADING]: Heading,
-  // [SECTIONS.TEXT_BLOCK]: TextBlock,
 
   // deprecated
   [SECTIONS.PROCEDURE]: () => <></>,
+  [SECTIONS.LEARNING_CHART]: () => <></>,
 
   [SECTIONS.TEACH_IT]: TeachIt,
-  [SECTIONS.LEARNING_CHART]: LearningChart,
   [SECTIONS.STANDARDS]: StandardsCollapsible,
   [SECTIONS.ACKNOWLEDGMENTS]: Acknowledgments,
   [SECTIONS.VERSIONS]: Versions,

--- a/components/LessonSection/index.js
+++ b/components/LessonSection/index.js
@@ -65,17 +65,10 @@ export const sectionTypeMap = {
   [SECTIONS.LESSON_PREVIEW_FORMER]: Preview,
 };
 
-const LessonSection = ({ index, section, _sectionDots, ForGrades }) => {
+const LessonSection = ({ index, section, _sectionDots }) => {
   const Component = sectionTypeMap[section.__component];
   let compProps = { ...section, _sectionDots };
   const parentId = `${section.SectionTitle}-parent-${index}`;
-
-  if ((typeof compProps.SectionTitle === "string") && compProps.SectionTitle.includes("Teaching Materials")) {
-    compProps = {
-      ...compProps,
-      ForGrades: ForGrades,
-    };
-  }
 
   return Component ? (
     <div id={parentId} className={`SectionHeading ${section.SectionTitle.replace(/[\s!]/gi, '_').toLowerCase()}`}>

--- a/components/LessonsPg/IndividualLesson.js
+++ b/components/LessonsPg/IndividualLesson.js
@@ -30,14 +30,16 @@ const IndividualLesson = ({ lesson, Pill = null }) => {
         </section>
         <section className='d-flex justify-content-end flex-column'>
           <div style={{ height: 90, width: 90 }} className="position-relative">
-            <Image
-              src={lesson.tile}
-              alt="lesson_tile"
-              fill
-              style={{ borderRadius: '.2em' }}
-              sizes="130px"
-              className="img-optimize h-100 w-100"
-            />
+            {lesson.tile && (
+              <Image
+                src={lesson.tile}
+                alt="lesson_tile"
+                fill
+                style={{ borderRadius: '.2em' }}
+                sizes="130px"
+                className="img-optimize h-100 w-100"
+              />
+            )}
             {Pill}
           </div>
         </section>

--- a/pages/_colors.scss
+++ b/pages/_colors.scss
@@ -28,6 +28,8 @@ $hydrogen-blue-highlight: #54adff4d;
 $math: #DB4125;
 $math-hl: lighten($math, 40%);
 
+$sel: #0070da;
+
 $ela: #df8c2d;
 $ela-hl: lighten($ela, 37%);
 

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -41,6 +41,26 @@ const getLessonSections = sectionComps => sectionComps.map((section, index) => (
   ...section,
   SectionTitle: `${index + 1}. ${section.SectionTitle}`,
 }));
+const addGradesOrYearsProperty = (sectionComps, ForGrades, GradesOrYears) => {
+  return sectionComps.map(section => {
+    if (section?.SectionTitle?.includes("Teaching Materials")) {
+      return {
+        ...section,
+        ForGrades: ForGrades,
+        GradesOrYears: GradesOrYears,
+      }
+    }
+
+    if (['lesson-plan.standards'].includes(section.__component)) {
+      return {
+        ...section,
+        GradesOrYears: GradesOrYears,
+      }
+    }
+
+    return section;
+  });
+}
 
 const LessonDetails = ({ lesson }) => {
   console.log("lesson: ", lesson);
@@ -63,18 +83,6 @@ const LessonDetails = ({ lesson }) => {
 
   if (sectionComps?.length) {
     sectionComps[0] = { ...sectionComps[0], SectionTitle: 'Overview' };
-    sectionComps = sectionComps.map(section => {
-      if(section?.SectionTitle?.includes("Teaching Materials")){
-        return {
-          ...section,
-          ForGrades: lesson.ForGrades,
-          GradesOrYears: lesson.GradesOrYears,
-        }
-      }
-
-      return section;
-    });
-    console.log("sectionComps: ", sectionComps);
   }
 
   if (lesson && !isTheLessonSectionInOneObj && lessonStandardsSections?.length) {
@@ -132,7 +140,8 @@ const LessonDetails = ({ lesson }) => {
     return true;
   })
 
-  const _dots = sectionComps ? getSectionDotsDefaultVal(sectionComps) : [];
+  sectionComps = useMemo(() => addGradesOrYearsProperty(sectionComps, lesson.ForGrades, lesson.GradesOrYears), [])
+  const _dots = useMemo(() => sectionComps ? getSectionDotsDefaultVal(sectionComps) : [], [])
   const [sectionDots, setSectionDots] = useState({
     dots: _dots,
     clickedSectionId: null,

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -56,10 +56,25 @@ const LessonDetails = ({ lesson }) => {
     return false;
   });
   const isTheLessonSectionInOneObj = lessonSectionObjEntries?.length ? lessonStandardsSections.length === 1 : false;
-  let sectionComps = lesson?.Section ? Object.values(lesson.Section).filter(({ SectionTitle }) => SectionTitle !== 'Procedure') : null;
+  let sectionComps = lesson?.Section ?
+    Object.values(lesson.Section).filter(({ SectionTitle }) => SectionTitle !== 'Procedure')
+    :
+    null;
 
   if (sectionComps?.length) {
     sectionComps[0] = { ...sectionComps[0], SectionTitle: 'Overview' };
+    sectionComps = sectionComps.map(section => {
+      if(section?.SectionTitle?.includes("Teaching Materials")){
+        return {
+          ...section,
+          ForGrades: lesson.ForGrades,
+          GradesOrYears: lesson.GradesOrYears,
+        }
+      }
+
+      return section;
+    });
+    console.log("sectionComps: ", sectionComps);
   }
 
   if (lesson && !isTheLessonSectionInOneObj && lessonStandardsSections?.length) {
@@ -170,7 +185,9 @@ const LessonDetails = ({ lesson }) => {
     return () => document.body.removeEventListener('click', handleDocumentClick);
   }, []);
 
-  let _sections = useMemo(() => sectionComps ? getLessonSections(sectionComps) : [], []);
+  const _sections = useMemo(() => sectionComps ? getLessonSections(sectionComps) : [], []);
+
+  console.log("_sections: ", _sections)
 
   if (!lesson && typeof window === "undefined") {
     return null;

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -128,7 +128,6 @@ const LessonDetails = ({ lesson }) => {
   })
 
   sectionComps = useMemo(() => addGradesOrYearsProperty(sectionComps, lesson.ForGrades, lesson.GradesOrYears), [])
-  console.log('sectionComps: ', sectionComps)
   const _dots = useMemo(() => sectionComps ? getSectionDotsDefaultVal(sectionComps) : [], [])
   const [sectionDots, setSectionDots] = useState({
     dots: _dots,

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -140,6 +140,7 @@ const LessonDetails = ({ lesson }) => {
   })
 
   sectionComps = useMemo(() => addGradesOrYearsProperty(sectionComps, lesson.ForGrades, lesson.GradesOrYears), [])
+  console.log('sectionComps: ', sectionComps)
   const _dots = useMemo(() => sectionComps ? getSectionDotsDefaultVal(sectionComps) : [], [])
   const [sectionDots, setSectionDots] = useState({
     dots: _dots,

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -43,6 +43,7 @@ const getLessonSections = sectionComps => sectionComps.map((section, index) => (
 }));
 
 const LessonDetails = ({ lesson }) => {
+  console.log("lesson: ", lesson);
   const router = useRouter();
   const lessonSectionObjEntries = lesson?.Section ? Object.entries(lesson.Section) : [];
   let lessonStandardsIndexesToFilterOut = [];

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -96,24 +96,12 @@ const LessonDetails = ({ lesson }) => {
       .reduce((lessonStandardObj, lessonStandardsAccumulatedObj) => {
         let _lessonStandardsAccumulated = { ...lessonStandardsAccumulatedObj };
 
-        if (!lessonStandardsAccumulatedObj.Badge && lessonStandardObj.Badge) {
-          _lessonStandardsAccumulated = { ..._lessonStandardsAccumulated, Badge: lessonStandardObj.Badge }
-        }
-
-        if (!lessonStandardsAccumulatedObj.Title && lessonStandardObj.Title) {
-          _lessonStandardsAccumulated = { ..._lessonStandardsAccumulated, Title: lessonStandardObj.Title };
-        }
-
         if (!lessonStandardsAccumulatedObj.SectionTitle && lessonStandardObj.SectionTitle) {
           _lessonStandardsAccumulated = { ..._lessonStandardsAccumulated, SectionTitle: lessonStandardObj.SectionTitle };
         }
 
         if (!lessonStandardsAccumulatedObj.Footnote && lessonStandardObj.Footnote) {
           _lessonStandardsAccumulated = { ..._lessonStandardsAccumulated, Footnote: lessonStandardObj.Footnote };
-        }
-
-        if (!lessonStandardsAccumulatedObj.Description && lessonStandardObj.Description) {
-          _lessonStandardsAccumulated = { ..._lessonStandardsAccumulated, Description: lessonStandardObj.Description };
         }
 
         return _lessonStandardsAccumulated;

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -63,7 +63,6 @@ const addGradesOrYearsProperty = (sectionComps, ForGrades, GradesOrYears) => {
 }
 
 const LessonDetails = ({ lesson }) => {
-  console.log("lesson: ", lesson);
   const router = useRouter();
   const lessonSectionObjEntries = lesson?.Section ? Object.entries(lesson.Section) : [];
   let lessonStandardsIndexesToFilterOut = [];
@@ -195,8 +194,6 @@ const LessonDetails = ({ lesson }) => {
   }, []);
 
   const _sections = useMemo(() => sectionComps ? getLessonSections(sectionComps) : [], []);
-
-  console.log("_sections: ", _sections)
 
   if (!lesson && typeof window === "undefined") {
     return null;

--- a/pages/style.scss
+++ b/pages/style.scss
@@ -299,6 +299,10 @@ ol li {
   background-color: $math;
 }
 
+.bg-sel{
+  background-color: $sel;
+}
+
 .bg-math-light {
   background-color: $math-hl;
 }


### PR DESCRIPTION
In this PR: 
- Using the 'GradesOrYears' variable for the target student age length for the gist card and the lesson part in the teacher's materials section.
- Fix the build error for the '/lesson/12'
- Change SEL standards color to #0070da 
- The learning chart has been deleted.

Receiving either `null` or `[null]` for the following properties for a JSON document: 
- `Section.preview.MultiMedia = [null]` 
- `teaching-materials.Data.classroom.resources[i].lessons[i].itemList[i].links[i].url = null`