### PR TITLE
Fixed get-users api route bug

### DIFF
--- a/.github/checkDeadLinks.js
+++ b/.github/checkDeadLinks.js
@@ -75,7 +75,6 @@
                 const randomNumMs =
                     Math.floor(Math.random() * (5000 - 1000 + 1)) + 1000;
                 const waitTime = randomNumMs + retries * 1_000;
-                console.log("Will wait for ", waitTime);
                 await new Promise((resolve) => setTimeout(resolve, waitTime));
                 return await sendEmailWithRetries(mailOpts, retries + 1);
             }

--- a/backend/services/emailServices.js
+++ b/backend/services/emailServices.js
@@ -218,6 +218,8 @@ export const getMailingListContact = async (email) => {
         const options = new BrevoOptions();
         const response = await fetch(`https://api.brevo.com/v3/contacts/${email}?identifierType=email_id`, options);
 
+        console.log('response, getting user from mailing list status: ', response.status);
+
         if (response.status === 429) {
             return email;
         }

--- a/backend/services/emailServices.js
+++ b/backend/services/emailServices.js
@@ -204,18 +204,23 @@ export const deleteUserFromMailingList = async (email) => {
 };
 
 /**
- * Finds the contact with the given email on the Brevo mailing list.
- * @param {string} email The email of the contact on the mailing list.
- * @return {Promise<Object | null>} A promise that resolves to the `Contact` object if the contact is found, otherwise `null`.
+ * Retrieves the Brevo contact information for the given email. 
+ * 
+ * @param {string} email The email of the target user.
+ * @returns {Promise<Object | string | null>} A promise that resolves to the Brevo contact information associated with the email. If the email is not found, null is returned. If Brevo returns a 429 status code, the email is returned as a string. If there is an error, null is returned.
  */
 export const getMailingListContact = async (email) => {
     try {
-        if (!email) {
-            throw new Error("The email was not provided.")
+        if (!email || (typeof email !== 'string')) {
+            throw new Error("The email was not provided or was not a string data type.")
         };
 
         const options = new BrevoOptions();
         const response = await fetch(`https://api.brevo.com/v3/contacts/${email}?identifierType=email_id`, options);
+
+        if (response.status === 429) {
+            return email;
+        }
 
         if (response.status !== 200) {
             return null;

--- a/backend/services/userServices.js
+++ b/backend/services/userServices.js
@@ -353,25 +353,14 @@ export const getUsersMailingListStatus = async (users) => {
     return users;
 };
 
-/**
- * Retrieves the mailing list status of a list of users from Brevo.
- *
- * If a 429 error occurs during status retrieval, it will retry up to 7 times with exponential backoff.
- * The function takes in an array of user objects, which must contain at least an 'email' property.
- * The function will return an object with a 'user' property containing all the users in the input array, with their mailing list status.
- * If there is an error, it will return an object with an 'errType' property and a 'msg' property containing an error message.
- *
- * @param {Array<Object>} usersToRetrieveStatus - An array of user objects, each containing at least an 'email' property.
- * @param {Array<Object>} allUsers - An array of user objects, which must contain all the users in 'usersToRetrieveStatus'.
- * @param {number} tries - The number of times the function has tried to retrieve the mailing list status of a user from Brevo.
- * @returns {Promise<{  user: Array<Object>} | { errType: string, msg: string }>} A promise that resolves to an object with a 'user' property containing all the users in the input array, with their mailing list status, or an object with an 'errType' property and a 'msg' property containing an error message.
- */
 export const getUserMailingListStatusWithRetries = async (
     usersToRetrieveStatus,
     allUsers,
     tries = 0
 ) => {
     try {
+        console.log("Current tries: ", tries);
+
         if (tries >= 7) {
             throw new CustomError("Reached max tries when retrieving the mailing list status of a user from Brevo.", undefined, "maxTriesExceeded");
         }
@@ -403,11 +392,16 @@ export const getUserMailingListStatusWithRetries = async (
             );
         }
 
-        return { users: [...usersMailingListStatus, ...allUsers] };
+        return {
+            users: [...usersMailingListStatus, ...allUsers]
+        };
     } catch (error) {
-        let { message, type } = error ?? {}
-        message = message ?? ("Failed to get the mailing list statuses of users. Reason: " + error)
+        let { message, type } = error ?? {};
+        message = message ?? `Failed to get the mailing list statuses of users. Reason: ${error}`
 
-        return { errType: type, msg: message };
+        return {
+            errorMessage: message,
+            errType: type
+        };
     }
 };

--- a/backend/services/userServices.js
+++ b/backend/services/userServices.js
@@ -1,11 +1,12 @@
 /* eslint-disable no-console */
 /* eslint-disable indent */
-import { sleep } from "../../globalFns.js";
+import { sleep, waitWithExponentialBackOff } from "../../globalFns.js";
 import { createDocument } from "../db/utils";
 import User from "../models/user";
 import { v4 as uuidv4 } from "uuid";
 import { findMailingListConfirmationByEmail } from "./mailingListConfirmationServices.js";
 import { getMailingListContact } from "./emailServices.js";
+import { CustomError } from "../utils/errors.js";
 
 export const getUsers = async (queryObj = {}, projectionObj = {}) => {
     try {
@@ -13,7 +14,6 @@ export const getUsers = async (queryObj = {}, projectionObj = {}) => {
 
         return { users };
     } catch (error) {
-
         return { errMsg: `Unable to retrieve all users. Reason: ${error}` };
     }
 };
@@ -259,17 +259,17 @@ export const createUser = async (
 };
 
 /**
- * Determines the mailing list status for each user in the provided array.
- * 
- * @param {Array} users - An array of user objects, each containing at least an email property.
- * @returns {Array} - The updated array of user objects with an added mailingListStatus property.
- * 
- * The function checks each user's email against the mailing list and updates their status. 
- * If a user is already on the mailing list, their status is set to "onList". 
- * If a user is not on the mailing list, it checks if a double opt-in email has been sent by 
- * querying confirmation documents. The status for users with a confirmation document is set to 
- * "doubleOptEmailSent", otherwise, it is set to "notOnList".
+ * Retrieves and updates the mailing list status for a list of users.
+ *
+ * @param {Array<Object>} users - An array of user objects, each containing at least an 'email' property.
+ * @returns {Promise<Array<Object>>} A promise that resolves to the updated array of user objects with their mailing list status.
+ *
+ * The function fetches mailing list status for each user by their email using the Brevo API.
+ * It sets the 'mailingListStatus' property to "onList", "notOnList", or "doubleOptEmailSent" based on the user's status.
+ * If a 429 error occurs during status retrieval, it adds 'didMailingListStatusRetrievalReqErr' as true.
+ * If the status is not directly retrievable, it checks for mailing list confirmation documents to determine the status.
  */
+
 export const getUsersMailingListStatus = async (users) => {
     const getUserMailingListStatusesPromises = users.map((user) =>
         getMailingListContact(user.email)
@@ -277,28 +277,44 @@ export const getUsersMailingListStatus = async (users) => {
     const userMailingListStatuses = await Promise.all(
         getUserMailingListStatusesPromises
     );
-    const notOnMailingListIndices = new Set();
+    const userEmailsNotOnMailingList = new Set();
 
     for (let index = 0; index < userMailingListStatuses.length; index++) {
         const userMailingListStatus = userMailingListStatuses[index];
 
-        if (userMailingListStatus !== null) {
+        if (userMailingListStatus && typeof userMailingListStatus === "object") {
             let targetUser = users[index];
             targetUser = {
                 ...targetUser,
                 mailingListStatus: "onList",
             };
+            delete targetUser.didMailingListStatusRetrievalReqErr;
             users[index] = targetUser;
             continue;
         }
 
-        notOnMailingListIndices.add(index);
+        if (typeof userMailingListStatus === "string") {
+            console.log(
+                "429 error has occurred for atleast one request that retrieve the mailling list status of a user."
+            );
+            let targetUser = users[index];
+            targetUser = {
+                ...targetUser,
+                didMailingListStatusRetrievalReqErr: true,
+            };
+            users[index] = targetUser;
+            continue;
+        }
+
+        const targetUser = users[index];
+
+        delete targetUser.didMailingListStatusRetrievalReqErr;
+
+        userEmailsNotOnMailingList.add(targetUser.email);
     }
 
-    if (notOnMailingListIndices.size) {
-        const emails = users
-            .filter((_, index) => notOnMailingListIndices.has(index))
-            .map((user) => user.email);
+    if (userEmailsNotOnMailingList.size) {
+        const emails = Array.from(userEmailsNotOnMailingList);
         const getUserMailingListConfirmationDocsPromises = emails.map((email) =>
             findMailingListConfirmationByEmail(email)
         );
@@ -335,4 +351,63 @@ export const getUsersMailingListStatus = async (users) => {
     }
 
     return users;
+};
+
+/**
+ * Retrieves the mailing list status of a list of users from Brevo.
+ *
+ * If a 429 error occurs during status retrieval, it will retry up to 7 times with exponential backoff.
+ * The function takes in an array of user objects, which must contain at least an 'email' property.
+ * The function will return an object with a 'user' property containing all the users in the input array, with their mailing list status.
+ * If there is an error, it will return an object with an 'errType' property and a 'msg' property containing an error message.
+ *
+ * @param {Array<Object>} usersToRetrieveStatus - An array of user objects, each containing at least an 'email' property.
+ * @param {Array<Object>} allUsers - An array of user objects, which must contain all the users in 'usersToRetrieveStatus'.
+ * @param {number} tries - The number of times the function has tried to retrieve the mailing list status of a user from Brevo.
+ * @returns {Promise<{  user: Array<Object>} | { errType: string, msg: string }>} A promise that resolves to an object with a 'user' property containing all the users in the input array, with their mailing list status, or an object with an 'errType' property and a 'msg' property containing an error message.
+ */
+export const getUserMailingListStatusWithRetries = async (
+    usersToRetrieveStatus,
+    allUsers,
+    tries = 0
+) => {
+    try {
+        if (tries >= 7) {
+            throw new CustomError("Reached max tries when retrieving the mailing list status of a user from Brevo.", undefined, "maxTriesExceeded");
+        }
+
+        const usersMailingListStatus = await getUsersMailingListStatus(
+            usersToRetrieveStatus
+        );
+        const usersOfFailedMailingListStatusReqErr = usersMailingListStatus.filter(
+            (user) => user.didMailingListStatusRetrievalReqErr
+        );
+
+        console.log(
+            "Failed to get the mailing list statuses of users: ",
+            usersOfFailedMailingListStatusReqErr.length
+        );
+
+        if (usersOfFailedMailingListStatusReqErr.length) {
+            const usersWithMailingListStatuses = usersMailingListStatus.filter(
+                (user) => !user.didMailingListStatusRetrievalReqErr
+            );
+
+            await waitWithExponentialBackOff(tries);
+
+            tries += 1;
+
+            return await getUserMailingListStatusWithRetries(
+                usersOfFailedMailingListStatusReqErr,
+                usersWithMailingListStatuses
+            );
+        }
+
+        return { users: [...usersMailingListStatus, ...allUsers] };
+    } catch (error) {
+        let { message, type } = error ?? {}
+        message = message ?? ("Failed to get the mailing list statuses of users. Reason: " + error)
+
+        return { errType: type, msg: message };
+    }
 };

--- a/backend/utils/connection.js
+++ b/backend/utils/connection.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import mongoose from "mongoose";
 import { waitWithExponentialBackOff } from "../../globalFns";
+import { ConversationsAgentOnlinePingPostRequest } from "@getbrevo/brevo";
 
 let isConnectedToDb = false;
 
@@ -71,3 +72,21 @@ export const connectToMongodb = async (
     return { wasSuccessful: false };
   }
 };
+
+export const connectToDbWithoutRetries = async () => {
+  try {
+    await mongoose.connect(createConnectionUri());
+
+    if (mongoose.connection.readyState !== 1) {
+      throw new Error("Ready state is not 1.");
+    }
+
+    console.log("Connection status: ", mongoose.connection);
+
+    return true;
+  } catch (error) {
+    console.error("Failed to connect to the database. Reason: ", error);
+
+    return false;
+  }
+}

--- a/backend/utils/connection.js
+++ b/backend/utils/connection.js
@@ -83,13 +83,18 @@ export const connectToMongodb = async (
 };
 
 export const connectToDbWithoutRetries = async (
-  dbType = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? "prod" : "dev"
+  dbType
 ) => {
   let targetDb = undefined;
+  let _dbType = dbType;
 
-  if (typeof dbType === "string") {
+  if (!_dbType) {
+    _dbType = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? "prod" : "dev"
+  }
+
+  if (typeof _dbType === "string") {
     targetDb =
-      dbType === "prod"
+      _dbType === "prod"
         ? process.env.MONGODB_DB_PROD
         : process.env.MONGODB_DB_NAME;
   }
@@ -103,12 +108,12 @@ export const connectToDbWithoutRetries = async (
       await mongoose.disconnect();
     }
 
-    if (typeof targetDb !== "string" && mongoose.connection.readyState === 1) {
+    if ((typeof targetDb !== "string") && mongoose.connection.readyState === 1) {
       console.log("Already connected to DB.");
       return true;
     }
 
-    await mongoose.connect(createConnectionUri(dbType));
+    await mongoose.connect(createConnectionUri(_dbType));
 
     if (mongoose.connection.readyState !== 1) {
       throw new Error("Ready state is not 1.");

--- a/globalFns.js
+++ b/globalFns.js
@@ -404,6 +404,8 @@ export const waitWithExponentialBackOff = async (num = 1) => {
         Math.floor(Math.random() * (5_500 - 1000 + 1)) + 1000;
     const waitTime = randomNumMs + (num * 1_000);
 
+    console.log("will wait for: ", waitTime);
+
     await sleep(waitTime);
 
     return num + 1;

--- a/pages/account.js
+++ b/pages/account.js
@@ -134,6 +134,7 @@ const AccountPg = () => {
     const [, setNotifyModal] = _notifyModal;
     const { status, data } = useSession();
     const { user, token } = data ?? {};
+    console.log("token: ", token);
     const { email, image, name } = user ?? {};
     const occupation = typeof localStorage === 'undefined' ? null : JSON.parse(localStorage.getItem('userAccount') ?? '{}').occupation;
     const firstName = aboutUserForm?.name?.first || (name?.first ?? '')

--- a/pages/api/get-users.js
+++ b/pages/api/get-users.js
@@ -2,8 +2,15 @@
 /* eslint-disable indent */
 /* eslint-disable no-unused-vars */
 /* eslint-disable quotes */
-import { getUsers, getUsersMailingListStatus } from "../../backend/services/userServices";
-import { connectToDbWithoutChecks, connectToMongodb } from "../../backend/utils/connection";
+import {
+    getUserMailingListStatusWithRetries,
+    getUsers,
+    getUsersMailingListStatus,
+} from "../../backend/services/userServices";
+import {
+    connectToDbWithoutRetries,
+    connectToMongodb,
+} from "../../backend/utils/connection";
 
 export const config = {
     maxDuration: 45,
@@ -12,7 +19,7 @@ export const config = {
 /**
  * @swagger
  * /api/get-users:
- *   description: Retrieves all users from the db along with their mailing list status. The client was must be authenticated as a database administrator to use this endpoint.
+ *   description: Retrieves all users from the db along with their mailing list status. The client was must be authenticated as a database administrator to use this endpoint. Will hit the brevo api. If a 429 error is encountered, then it will retry up to 7 times.
  *   requiresAuth: true
  *   requiresDbAdminAuth: true
  *   requestBodyComments: "No request body. Do not set one."
@@ -26,7 +33,7 @@ export const config = {
  *       200:
  *         body: { users: "{ ...UserSchema, mailingListStatus: 'onList' | 'notOnList' | 'doubleOptEmailSent' }[]"}
  *       500:
- *         body: { errMsg: "A message describing the error. Possible reasons: Failed to connect to the database | Failed to retrieve all users." }
+ *         body: { errMsg: "A message describing the error. Possible reasons: Failed to connect to the database | Failed to retrieve all users | Reached max triese when retrieving the mailing list status of a user from Brevo." }
  */
 
 /**
@@ -38,19 +45,27 @@ export const config = {
 export default async function handler(request, response) {
     try {
         if (request.method !== "GET") {
-            return response.status(405).json({ errMsg: "Incorrect request method. Must be a 'GET'." });
+            return response
+                .status(405)
+                .json({ errMsg: "Incorrect request method. Must be a 'GET'." });
         }
 
-        const isDbConnected = await connectToDbWithoutChecks();
+        const { dbType } = request.query;
+
+        const isDbConnected = await connectToDbWithoutRetries(dbType);
 
         if (!isDbConnected) {
-            return response.status(500).json({ errMsg: "Failed to connect to the database." });
+            return response
+                .status(500)
+                .json({ errMsg: "Failed to connect to the database." });
         }
 
         let { errMsg, users } = await getUsers();
 
         if (errMsg || !users) {
-            return response.status(500).json({ errMsg: errMsg ?? "Failed to retrieve all users." });
+            return response
+                .status(500)
+                .json({ errMsg: errMsg ?? "Failed to retrieve all users." });
         }
 
         if (users.length === 0) {
@@ -59,9 +74,14 @@ export default async function handler(request, response) {
             return response.status(200).json({ users });
         }
 
-        users = await getUsersMailingListStatus(users);
+        const { users: usersWithMailingListStatus, errType, msg } = await getUserMailingListStatusWithRetries(
+            users,
+            []
+        );
 
-        return response.status(200).json({ users });
+        return response
+            .status(usersWithMailingListStatus ? 200 : 500)
+            .json({ users, errMsg: msg ?? null, errType });
     } catch (error) {
         console.error(
             "Failed to retrieve the target users from the db. Reason: ",

--- a/pages/lessons/[loc]/[id]/index.js
+++ b/pages/lessons/[loc]/[id]/index.js
@@ -263,7 +263,7 @@ const LessonDetails = ({ lesson }) => {
 
     sectionCompsCopy.splice(teachingMaterialsSecIndex + 1, 0, feedBackSec)
 
-    return sectionCompsCopy
+    return sectionCompsCopy;
   }, [])
 
   let _sections = useMemo(


### PR DESCRIPTION
- You should get 13 users on the mailing list when you query for the prod db. And 4 on dev. In other words, the number should be consistent for every request. 
- A config object was added to the get-user route. It will extend the time if a request takes time to complete when querying the DB. Mongoose is used to check the connection state for this route. 